### PR TITLE
Stronger tracing tests with inline-snapshot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "mkdocstrings[python]>=0.28.0",
     "coverage>=7.6.12",
     "playwright==1.50.0",
+    "inline-snapshot>=0.20.5",
 ]
 [tool.uv.workspace]
 members = ["agents"]

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 import pytest
+from inline_snapshot import snapshot
 from typing_extensions import TypedDict
 
 from agents import (
@@ -27,7 +28,7 @@ from .test_responses import (
     get_handoff_tool_call,
     get_text_message,
 )
-from .testing_processor import fetch_ordered_spans, fetch_traces
+from .testing_processor import fetch_normalized_spans, fetch_ordered_spans, fetch_traces
 
 
 @pytest.mark.asyncio
@@ -44,6 +45,34 @@ async def test_single_turn_model_error():
 
     traces = fetch_traces()
     assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
+
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "data": {
+                            "name": "test_agent",
+                            "handoffs": [],
+                            "tools": [],
+                            "output_type": "str",
+                        },
+                        "children": [
+                            {
+                                "type": "generation",
+                                "error": {
+                                    "message": "Error",
+                                    "data": {"name": "ValueError", "message": "test error"},
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
 
     spans = fetch_ordered_spans()
     assert len(spans) == 2, f"should have agent and generation spans, got {len(spans)}"
@@ -80,6 +109,43 @@ async def test_multi_turn_no_handoffs():
     traces = fetch_traces()
     assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
 
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "data": {
+                            "name": "test_agent",
+                            "handoffs": [],
+                            "tools": ["foo"],
+                            "output_type": "str",
+                        },
+                        "children": [
+                            {"type": "generation"},
+                            {
+                                "type": "function",
+                                "data": {
+                                    "name": "foo",
+                                    "input": '{"a": "b"}',
+                                    "output": "tool_result",
+                                },
+                            },
+                            {
+                                "type": "generation",
+                                "error": {
+                                    "message": "Error",
+                                    "data": {"name": "ValueError", "message": "test error"},
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+
     spans = fetch_ordered_spans()
     assert len(spans) == 4, (
         f"should have agent, generation, tool, generation, got {len(spans)} with data: "
@@ -109,6 +175,39 @@ async def test_tool_call_error():
 
     traces = fetch_traces()
     assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
+
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "data": {
+                            "name": "test_agent",
+                            "handoffs": [],
+                            "tools": ["foo"],
+                            "output_type": "str",
+                        },
+                        "children": [
+                            {"type": "generation"},
+                            {
+                                "type": "function",
+                                "error": {
+                                    "message": "Error running tool",
+                                    "data": {
+                                        "tool_name": "foo",
+                                        "error": "Invalid JSON input for tool foo: bad_json",
+                                    },
+                                },
+                                "data": {"name": "foo", "input": "bad_json"},
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
 
     spans = fetch_ordered_spans()
     assert len(spans) == 3, (
@@ -159,6 +258,43 @@ async def test_multiple_handoff_doesnt_error():
     traces = fetch_traces()
     assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
 
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "data": {
+                            "name": "test",
+                            "handoffs": ["test", "test"],
+                            "tools": ["some_function"],
+                            "output_type": "str",
+                        },
+                        "children": [
+                            {"type": "generation"},
+                            {
+                                "type": "function",
+                                "data": {
+                                    "name": "some_function",
+                                    "input": '{"a": "b"}',
+                                    "output": "result",
+                                },
+                            },
+                            {"type": "generation"},
+                            {"type": "handoff", "data": {"from_agent": "test", "to_agent": "test"}},
+                        ],
+                    },
+                    {
+                        "type": "agent",
+                        "data": {"name": "test", "handoffs": [], "tools": [], "output_type": "str"},
+                        "children": [{"type": "generation"}],
+                    },
+                ],
+            }
+        ]
+    )
+
     spans = fetch_ordered_spans()
     assert len(spans) == 7, (
         f"should have 2 agent, 1 function, 3 generation, 1 handoff, got {len(spans)} with data: "
@@ -192,6 +328,21 @@ async def test_multiple_final_output_doesnt_error():
 
     traces = fetch_traces()
     assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
+
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "data": {"name": "test", "handoffs": [], "tools": [], "output_type": "Foo"},
+                        "children": [{"type": "generation"}],
+                    }
+                ],
+            }
+        ]
+    )
 
     spans = fetch_ordered_spans()
     assert len(spans) == 2, (
@@ -251,6 +402,76 @@ async def test_handoffs_lead_to_correct_agent_spans():
     traces = fetch_traces()
     assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
 
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "data": {
+                            "name": "test_agent_3",
+                            "handoffs": ["test_agent_1", "test_agent_2"],
+                            "tools": ["some_function"],
+                            "output_type": "str",
+                        },
+                        "children": [
+                            {"type": "generation"},
+                            {
+                                "type": "function",
+                                "data": {
+                                    "name": "some_function",
+                                    "input": '{"a": "b"}',
+                                    "output": "result",
+                                },
+                            },
+                            {"type": "generation"},
+                            {
+                                "type": "handoff",
+                                "data": {"from_agent": "test_agent_3", "to_agent": "test_agent_1"},
+                            },
+                        ],
+                    },
+                    {
+                        "type": "agent",
+                        "data": {
+                            "name": "test_agent_1",
+                            "handoffs": ["test_agent_3"],
+                            "tools": ["some_function"],
+                            "output_type": "str",
+                        },
+                        "children": [
+                            {"type": "generation"},
+                            {
+                                "type": "function",
+                                "data": {
+                                    "name": "some_function",
+                                    "input": '{"a": "b"}',
+                                    "output": "result",
+                                },
+                            },
+                            {"type": "generation"},
+                            {
+                                "type": "handoff",
+                                "data": {"from_agent": "test_agent_1", "to_agent": "test_agent_3"},
+                            },
+                        ],
+                    },
+                    {
+                        "type": "agent",
+                        "data": {
+                            "name": "test_agent_3",
+                            "handoffs": ["test_agent_1", "test_agent_2"],
+                            "tools": ["some_function"],
+                            "output_type": "str",
+                        },
+                        "children": [{"type": "generation"}],
+                    },
+                ],
+            }
+        ]
+    )
+
     spans = fetch_ordered_spans()
     assert len(spans) == 12, (
         f"should have 3 agents, 2 function, 5 generation, 2 handoff, got {len(spans)} with data: "
@@ -285,6 +506,38 @@ async def test_max_turns_exceeded():
     traces = fetch_traces()
     assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
 
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "error": {"message": "Max turns exceeded", "data": {"max_turns": 2}},
+                        "data": {
+                            "name": "test",
+                            "handoffs": [],
+                            "tools": ["foo"],
+                            "output_type": "Foo",
+                        },
+                        "children": [
+                            {"type": "generation"},
+                            {
+                                "type": "function",
+                                "data": {"name": "foo", "input": "", "output": "result"},
+                            },
+                            {"type": "generation"},
+                            {
+                                "type": "function",
+                                "data": {"name": "foo", "input": "", "output": "result"},
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+
     spans = fetch_ordered_spans()
     assert len(spans) == 5, (
         f"should have 1 agent span, 2 generations, 2 function calls, got "
@@ -317,6 +570,30 @@ async def test_guardrail_error():
 
     traces = fetch_traces()
     assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
+
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "error": {
+                            "message": "Guardrail tripwire triggered",
+                            "data": {"guardrail": "guardrail_function"},
+                        },
+                        "data": {"name": "test", "handoffs": [], "tools": [], "output_type": "str"},
+                        "children": [
+                            {
+                                "type": "guardrail",
+                                "data": {"name": "guardrail_function", "triggered": True},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
 
     spans = fetch_ordered_spans()
     assert len(spans) == 2, (

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918 },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -241,6 +250,15 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -390,6 +408,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "inline-snapshot"
+version = "0.20.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/95/9b85a63031c168dd1c479f8cfd5cae42d42d6ac41c18dd760a104bc87ddc/inline_snapshot-0.20.5.tar.gz", hash = "sha256:d8b67c6d533c0a3f566e72608144b54da65dc3da5d0dba4169b2c56b75530fb5", size = 92215 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/71/34e775bbf0bcf81d588d80a1df93437f937b0df9a841f246606a03fc5eff/inline_snapshot-0.20.5-py3-none-any.whl", hash = "sha256:3aa56acf5985d89f17ebd4df4aef00faacc49f10cdf4e6b42be701ffc9702b5a", size = 48071 },
 ]
 
 [[package]]
@@ -797,6 +830,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "inline-snapshot" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -822,6 +856,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.6.12" },
+    { name = "inline-snapshot", specifier = ">=0.20.5" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-material", specifier = ">=9.6.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.28.0" },


### PR DESCRIPTION
`assert len(spans) == 12` is a very weak assertion. This PR asserts the exported traces and spans more precisely. And when the format of an exported trace/span changes, you can use `pytest --inline-snapshot=fix` to update all relevant tests automatically. See https://15r10nk.github.io/inline-snapshot/latest/ for more info.